### PR TITLE
fix AttributeError in unsupported policies

### DIFF
--- a/security_monkey/watchers/iam/iam_group.py
+++ b/security_monkey/watchers/iam/iam_group.py
@@ -35,16 +35,19 @@ def all_managed_policies(conn):
 
     for policy in conn.policies.all():
         for attached_group in policy.attached_groups.all():
-            policy = {
-                "name": policy.policy_name,
-                "arn": policy.arn,
-                "version": policy.default_version_id
-            }
+            try:
+                policy = {
+                    "name": policy.policy_name,
+                    "arn": policy.arn,
+                    "version": policy.default_version_id
+                }
 
-            if attached_group.arn not in managed_policies:
-                managed_policies[attached_group.arn] = [policy]
-            else:
-                managed_policies[attached_group.arn].append(policy)
+                if attached_group.arn not in managed_policies:
+                    managed_policies[attached_group.arn] = [policy]
+                else:
+                    managed_policies[attached_group.arn].append(policy)
+            except AttributeError:
+                print "AttributeError for %s." % policy
 
     return managed_policies
 

--- a/security_monkey/watchers/iam/iam_role.py
+++ b/security_monkey/watchers/iam/iam_role.py
@@ -36,16 +36,19 @@ def all_managed_policies(conn):
 
     for policy in conn.policies.all():
         for attached_role in policy.attached_roles.all():
-            policy = {
-                "name": policy.policy_name,
-                "arn": policy.arn,
-                "version": policy.default_version_id
-            }
+            try:
+                policy = {
+                    "name": policy.policy_name,
+                    "arn": policy.arn,
+                    "version": policy.default_version_id
+                }
 
-            if attached_role.arn not in managed_policies:
-                managed_policies[attached_role.arn] = [policy]
-            else:
-                managed_policies[attached_role.arn].append(policy)
+                if attached_role.arn not in managed_policies:
+                    managed_policies[attached_role.arn] = [policy]
+                else:
+                    managed_policies[attached_role.arn].append(policy)
+            except AttributeError:
+                print "AttributeError for %s." % policy
 
     return managed_policies
 

--- a/security_monkey/watchers/iam/iam_user.py
+++ b/security_monkey/watchers/iam/iam_user.py
@@ -35,16 +35,19 @@ def all_managed_policies(conn):
 
     for policy in conn.policies.all():
         for attached_user in policy.attached_users.all():
-            policy = {
-                "name": policy.policy_name,
-                "arn": policy.arn,
-                "version": policy.default_version_id
-            }
+            try:
+                policy = {
+                    "name": policy.policy_name,
+                    "arn": policy.arn,
+                    "version": policy.default_version_id
+                }
 
-            if attached_user.arn not in managed_policies:
-                managed_policies[attached_user.arn] = [policy]
-            else:
-                managed_policies[attached_user.arn].append(policy)
+                if attached_user.arn not in managed_policies:
+                    managed_policies[attached_user.arn] = [policy]
+                else:
+                    managed_policies[attached_user.arn].append(policy)
+            except AttributeError:
+                print "AttributeError for %s." % policy
 
     return managed_policies
 


### PR DESCRIPTION
/cc @philsnow 

Because of AttributeError, changes of iamrole, iamgroup, and iamuser cannot be monitored.  Here I fix AttributeError in unsupported policies and then security monkey will ignore unsupported policies, e.g. EMR related polices.
